### PR TITLE
Add docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM  ubuntu:16.04
+FROM  node:8.5
+# Copy contents into the gateway container
+ADD . /server
+# Set the working directory to   container
+WORKDIR /server
+COPY package.json /server/package.json
+
+# Added node_modules to .dockerignore (size)
+RUN npm install
+# Define environment variable
+ENV Name PR_API_SERVER

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-FROM  ubuntu:16.04
 FROM  node:8.5
 # Copy contents into the gateway container
 ADD . /server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3"
+services:
+    gateway:
+        build: .
+        depends_on:
+            - mongo
+        links:
+            - mongo
+        environment:
+            NODE_ENV: development
+            MONGO_URL: mongodb://mongo/DemoApp
+        entrypoint: "node app"
+    mongo:
+        image: mongo


### PR DESCRIPTION
commit 69a9e550edb78ff5252aadb26366b896c11a226e
>>>>
Add docker and docker-compose files
Allow the app to run over a docker container. The database is named inside of docker-compose.yml.

In order to don't need to install everything to be up and runing for tests, the user just need to run sudo docker-compose build && sudo docker-compose up. This is usefull to who just want to run the application in local machine.

commit e16a4e0696aa4316cfec00a4b737cc359228d2fe
>>> 
Remove image linux
Wrong call for Ubuntu Volume.